### PR TITLE
Add CSV writer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,13 @@ $ cd /path/to/prometheus/data/snapshots/20200110T104512Z-xxxxxxxxxxxx
 $ parallelism="$(nproc)"
 $ find . -mindepth 1 -maxdepth 1 -type d | xargs -n1 -P "$parallelism" sh -c 'echo $0; prometheus-tsdb-dump-linux -block "$0" -format victoriametrics | curl http://your-victoriametrics:8428/api/v1/import -T -'
 ```
+
+### `csv`
+
+The `csv` format outputs one sample per line in comma separated form. Each row contains the metric name (`__name__`), the timestamp in milliseconds, the value, and then the values of remaining labels sorted by their name.
+
+Example:
+
+```
+up,1578636058619,1,a,node-exporter
+```

--- a/pkg/writer/csv.go
+++ b/pkg/writer/csv.go
@@ -1,0 +1,48 @@
+package writer
+
+import (
+	"encoding/csv"
+	"os"
+	"sort"
+	"strconv"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// CSVWriter writes samples in CSV format.
+type CSVWriter struct {
+	enc *csv.Writer
+}
+
+// NewCSVWriter creates a writer that outputs CSV to stdout.
+func NewCSVWriter() (*CSVWriter, error) {
+	return &CSVWriter{enc: csv.NewWriter(os.Stdout)}, nil
+}
+
+// Write writes the given samples as CSV rows. Each row consists of the metric
+// name, timestamp, value and the values of other labels sorted by their name.
+func (w *CSVWriter) Write(lbls *labels.Labels, timestamps []int64, values []float64) error {
+	var name string
+	other := make([]labels.Label, 0, len(*lbls))
+	for _, l := range *lbls {
+		if l.Name == "__name__" {
+			name = l.Value
+			continue
+		}
+		other = append(other, l)
+	}
+	sort.Slice(other, func(i, j int) bool { return other[i].Name < other[j].Name })
+
+	for i := range timestamps {
+		row := make([]string, 0, 3+len(other))
+		row = append(row, name, strconv.FormatInt(timestamps[i], 10), strconv.FormatFloat(values[i], 'f', -1, 64))
+		for _, l := range other {
+			row = append(row, l.Value)
+		}
+		if err := w.enc.Write(row); err != nil {
+			return err
+		}
+	}
+	w.enc.Flush()
+	return w.enc.Error()
+}

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -13,6 +13,8 @@ func NewWriter(format string) (Writer, error) {
 	switch format {
 	case "victoriametrics":
 		return NewVictoriaMetricsWriter()
+	case "csv":
+		return NewCSVWriter()
 	}
 	return nil, fmt.Errorf("invalid format: %s", format)
 }


### PR DESCRIPTION
## Summary
- support `csv` output format alongside `victoriametrics`
- document csv format

## Testing
- `GOPROXY=direct go build ./...`
- `GOPROXY=direct go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844418ee6ac832fa7440e8a87ad2d97