### PR TITLE
Add aws profile flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ $ prometheus-tsdb-dump -block /path/to/prometheus-data/block-ulid -format victor
 - `-max-timestamp`: Maximum timestamp of exported samples (unix time in msec)
 - `-dump-index`: Dump block index information. The block path can point to a
   local directory or an `s3://` location.
+- `-aws-profile`: AWS profile to use when accessing S3 for `-dump-index`
 
 ## Output Formats
 


### PR DESCRIPTION
## Summary
- add `-aws-profile` option for S3 access
- support optional profile when downloading index from S3
- document new argument

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68444c0a6738832f85c67868cf4e84da