### PR TITLE
Add metric-name filter without overriding label filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ $ prometheus-tsdb-dump -block /path/to/prometheus-data/block-ulid -format victor
   when reading a block from S3 with `-block`
 - `-output`: Write output to the given file instead of stdout
 - `-label-value`: Comma-separated list of label values to filter by
+- `-label-key`: Label name to apply with `-label-value`
+- `-metric-name`: Dump only the series or index for the given metric name
+
+`-metric-name` can be used together with `-label-key` and `-label-value` to
+filter by a specific metric and label value at the same time.
 
 ## Output Formats
 


### PR DESCRIPTION
## Summary
- add `-label-key` documentation
- allow `-metric-name` to combine with label filtering
- ensure default to all postings when no label key provided

## Testing
- `make build` *(fails: forbidden fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_684455922604832fac1976b27a9000d1