### PR TITLE
Fix bucket region autodetection

### DIFF
--- a/main.go
+++ b/main.go
@@ -432,7 +432,9 @@ func newAWSConfig(ctx context.Context, bucket, profile string) (aws.Config, erro
 		return aws.Config{}, err
 	}
 	if cfg.Region == "" {
-		region, err := manager.GetBucketRegion(ctx, s3.NewFromConfig(cfg), bucket)
+		cfgHint := cfg
+		cfgHint.Region = "us-east-1"
+		region, err := manager.GetBucketRegion(ctx, s3.NewFromConfig(cfgHint), bucket)
 		if err != nil {
 			return aws.Config{}, err
 		}


### PR DESCRIPTION
## Summary
- ensure S3 bucket region lookup works without preconfigured region

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845d394fb18832fb71ec77d4ec5242c